### PR TITLE
Add option to specify a single tool to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Allows specifying the project path. Useful for repos that do not conform to the 
 
 Defaults to the repository root.
 
+### `tool` (Optional, string)
+
+Allows a specific tool to be specified for installation by asdf.
+
+This can be useful if multiple tools are specified in the repository but you only need one for this particular task.
+
+```yaml
+steps:
+  - command: terraform init && terraform plan
+    plugins:
+      - byerobot/asdf#v1.2.2:
+          tool: terraform
+```
+
 ## Contributing
 
 1. Fork the repo

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -28,7 +28,8 @@ done < .tool-versions
 echo "~~~ :toolbox: Installing asdf tool versions"
 asdf install "$tool"
 
-if grep -q nodejs .tool-versions; then
+# If nodejs requested via $tool or in tool-versions install npm
+if [[ -z "$tool" || "$tool" == "nodejs" ]] && grep -q nodejs .tool-versions; then
   echo "~~~ :yarn: Installing yarn"
   npm i -g yarn
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
-ASDF_VERSION="v0.10.0"
+ASDF_VERSION="v0.10.2"
 path=$(echo "${BUILDKITE_PLUGIN_ASDF_PATH:-.}" | sed 's/^\///') # strip prefixed slashes
+tool=${BUILDKITE_PLUGIN_ASDF_TOOL:-} # allow specific tool to be installed
 
 echo "--- :wrench: Configuring tools with asdf"
 pushd "$path" || exit 1
@@ -25,7 +26,7 @@ do
 done < .tool-versions
 
 echo "~~~ :toolbox: Installing asdf tool versions"
-asdf install
+asdf install "$tool"
 
 if grep -q nodejs .tool-versions; then
   echo "~~~ :yarn: Installing yarn"

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,4 +6,6 @@ configuration:
   properties:
     path:
       type: string
+    tool:
+      type: string
   additionalProperties: false


### PR DESCRIPTION
First of all, thanks for the useful plugin. We are using this regularly now for our terraform Buildkite pipelines. 
Some of our repos have multiple tools specified in the `.tool-versions` file and it is not always desirable to install them all. 

This PR adds the option `tool` to allow the user to instruct the plugin to only install a single tool during execution. It will still respect the version listed in the `.tool-versions` file and error if it is not listed within it. 

This was initially a very small change but I had to add some additional logic to handle the npm install and skip this if nodejs wasn't the tool requested. 

I also bumped asdf to the latest version. 

I welcome your feedback. 